### PR TITLE
AC-6694 - make django-bootstrap Python 2/3 compatible

### DIFF
--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -1,14 +1,15 @@
 import os
-from django.template import Context,RequestContext
+from django.template import Context
 from django.template.loader import get_template, select_template
 from django.utils.safestring import mark_safe
-from django.utils.html import escape
 from django import forms
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_text
+
 
 class NoSuchFormField(Exception):
     """""The form field couldn't be resolved."""""
     pass
+
 
 class BootstrapMixin(object):
 
@@ -65,17 +66,12 @@ class BootstrapMixin(object):
         return mark_safe(prefix + errors + output)
 
     def render_fields(self, fields, separator=u""):
-        """ Render a list of fields and join the fields by the value in separator. """
-
         output = []
-
         for field in fields:
             if isinstance(field, Fieldset):
                 output.append(field.as_html(self))
             else:
                 output.append(self.render_field(field))
-
-
         return separator.join(output)
 
     def render_field(self, field):
@@ -91,9 +87,6 @@ class BootstrapMixin(object):
         output = ''
 
         if bf.errors:
-            # If the field contains errors, render the errors to a <ul>
-            # using the error_list helper function.
-            # bf_errors = error_list([escape(error) for error in bf.errors])
             bf_errors = ', '.join([e for e in bf.errors])
         else:
             bf_errors = ''
@@ -110,7 +103,8 @@ class BootstrapMixin(object):
         else:
 
             # Find field + widget type css classes
-            css_class = type(field_instance).__name__ + " " +  type(field_instance.widget).__name__
+            css_class = type(field_instance).__name__ + " " + type(
+                field_instance.widget).__name__
 
             # Add an extra class, Required, if applicable
             if field_instance.required:
@@ -118,27 +112,29 @@ class BootstrapMixin(object):
 
             if field_instance.help_text:
                 # The field has a help_text, construct <span> tag
-                help_text = '<span class="help-%s">%s</span>' % (self.help_style, force_unicode(field_instance.help_text))
+                help_text = '<span class="help-%s">%s</span>' % (
+                    self.help_style, force_text(field_instance.help_text))
             else:
                 help_text = u''
 
             field_hash = {
-                'class' : mark_safe(css_class),
-                'label' : mark_safe(bf.label or ''),
-                'help_text' :mark_safe(help_text),
-                'field' : field_instance,
-                'bf' : mark_safe(unicode(bf)),
-                'bf_raw' : bf,
-                'errors' : mark_safe(bf_errors),
-                'field_type' : mark_safe(field.__class__.__name__),
+                'class': mark_safe(css_class),
+                'label': mark_safe(bf.label or ''),
+                'help_text': mark_safe(help_text),
+                'field': field_instance,
+                'bf': mark_safe(unicode(bf)),
+                'bf_raw': bf,
+                'errors': mark_safe(bf_errors),
+                'field_type': mark_safe(field.__class__.__name__),
                 'label_id': bf._auto_id(),
             }
 
-            if self.custom_fields.has_key(field):
+            if field in self.custom_fields:
                 template = get_template(self.custom_fields[field])
             else:
                 template = select_template([
-                    os.path.join(self.template_base, 'field_%s.html' % type(field_instance.widget).__name__.lower()),
+                    os.path.join(self.template_base, 'field_%s.html' % type(
+                        field_instance.widget).__name__.lower()),
                     os.path.join(self.template_base, 'field_default.html'), ])
 
             # Finally render the field
@@ -165,9 +161,11 @@ class Fieldset(object):
     def __init__(self, legend, *fields, **kwargs):
         self.legend = legend
         self.fields = fields
-        self.css_class = kwargs.get('css_class', '_'.join(legend.lower().split()))
+        self.css_class = kwargs.get('css_class', '_'.join(
+            legend.lower().split()))
 
     def as_html(self, form):
-        legend_html = self.legend and (u'<legend>%s</legend>' % self.legend) or ''
-        return u'<fieldset class="%s">%s%s</fieldset>' % (self.css_class, legend_html, form.render_fields(self.fields))
-
+        legend_html = self.legend and (
+            u'<legend>%s</legend>' % self.legend) or ''
+        return u'<fieldset class="%s">%s%s</fieldset>' % (
+            self.css_class, legend_html, form.render_fields(self.fields))

--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -5,6 +5,12 @@ from django.utils.safestring import mark_safe
 from django import forms
 from django.utils.encoding import force_text
 
+# Python 3 quick fix
+try:
+    from builtins import str as unicode
+except ImportError:
+    pass
+
 
 class NoSuchFormField(Exception):
     """""The form field couldn't be resolved."""""

--- a/bootstrap/runtests.py
+++ b/bootstrap/runtests.py
@@ -2,7 +2,7 @@ import os, sys
 from django.conf import settings
 
 DIRNAME = os.path.dirname(__file__)
-print settings.configured
+print(settings.configured)
 settings.configure(DEBUG = True,
                    DATABASE_ENGINE = 'django.db.backends.sqlite3',
                    DATABASE_NAME = os.path.join(DIRNAME, 'database.db'),


### PR DESCRIPTION
## [AC-6768](https://masschallenge.atlassian.net/browse/AC-6768)

The **django-bootstrap** package (unmaintained) is not currently compatible with Python 3. 

This branch contains minimal changes (plus some lint cleanup) to make it compatible with both Python 2 and Python 3 -- so it can continue to be used as a dependency in our current (py2-based) accelerate, and can also be used as a dependency in our Python 3 based version (currently found in AC-6694).

E.g. 
```python
File "/srv/www/mc/current/src/django-bootstrap/bootstrap/forms.py", line 7, in <module>
    from django.utils.encoding import force_unicode
ImportError: cannot import name 'force_unicode'
```

**Testing**
* Get the code (note: branch is called **AC-6694** because it was created before this ticket existed):
```shell
git clone https://github.com/masschallenge/django-bootstrap
cd django-bootstrap
git checkout AC-6694
```
* Create a Python 2 virtualenv, activate it, and `pip install 'django<2'`
* Confirm that `python bootstrap/forms.py` does not raise an exception.
* Create a Python 3 virtualenv, activate it, and `pip install 'django<2'`
* Confirm that `python bootstrap/forms.py` does not raise an exception.
* Bonus: with your Python 3 venv still active, `git checkout master` and see that `python bootstrap.py` _does_ raise an exception.